### PR TITLE
Added docente link conversion

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -22,9 +22,16 @@ function run(){
         });
         break;
       case "docente":
-        //TODO put this in a red box
-        text_out.value = "Calendari per docente non ancora supportati. Contattami per richiedere la funzione.";
-        return;
+        new_uri.search(
+          { "form-type": "docente"
+          , "anno": old_search["anno"]
+          , "docente": old_search["docente"]
+          , "date": old_search["date"] // needed to avoid getting lectures of first semester when downloading last semester
+          , "attivita": old_search["attivita"]
+          , "ar_codes_": old_search["ar_codes_"]
+          , "ar_select_": old_search["ar_select_"]
+        });
+       break;
       case "attivita":
         new_uri.search(
           { "form-type": "attivita"

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           e, una volta completato il
           (lungo) caricamento, copia l'indirizzo della pagina
           (è qualcosa del tipo <kbd>https://easyroom.unitn.it/Orario/…</kbd>).
-          Se appare il messaggio "Nessun corso trovato", non preoccuparti:
+          Se appare il messaggio "Nessun insegnamento presente" oppure "Nessun corso trovato", non preoccuparti:
           funzionerà lo stesso, copia comunque l'indirizzo.
         </p>
       </div>


### PR DESCRIPTION
I added the code need to convert `docente` urls. I tested it with links like 
```
https://easyroom.unitn.it/Orario/index.php?view=easycourse&include=docente&list=0&anno=2018&docente=004609&visualizzazione_orario=cal&date=22-02-2019&periodo_didattico=&_lang=en&ar_codes_=EC145413_MOD2_KUPER_LEZ|EC145084_KUPER&col_cells=0&ar_select_=false|true&all_events=1
```
that has selected inside subjects that are selected and subjects that are not, and work fine.

Closes #2